### PR TITLE
Fix motion paths not working in 3.3

### DIFF
--- a/Mesh_Onion_Skins.py
+++ b/Mesh_Onion_Skins.py
@@ -1850,14 +1850,14 @@ def create_update_motion_path(context, mode, obj, fs, fe, kfbefore, kfafter):
     if mode == 'POSE':
         if mp.has_motion_paths is True:
             bpy.ops.pose.paths_clear(only_selected=False)
-        bpy.ops.pose.paths_calculate(start_frame=fs, end_frame=fe+1)
+        bpy.ops.object.paths_calculate(display_type="RANGE", range="KEYS_ALL")
     elif mode == 'OBJECT':
         if mp.has_motion_paths is True:
             if sc.os_draw_mode == 'MESH':
                 bpy.ops.object.paths_clear(only_selected=False)
             else:
                 bpy.ops.object.paths_clear(only_selected=True)
-        bpy.ops.object.paths_calculate(start_frame=fs, end_frame=fe + 1)
+        bpy.ops.object.paths_calculate(display_type="RANGE", range="KEYS_ALL")
     bpy.ops.object.mode_set(mode=mode)
 
 


### PR DESCRIPTION
Seems like an API change that stopped the motion paths working in 3.3. Probably even 3.2.
https://docs.blender.org/api/current/bpy.ops.object.html#bpy.ops.object.paths_calculate