### PR TITLE
Fixes the creation of onion skins for blender 4.2+

### DIFF
--- a/Mesh_Onion_Skins.py
+++ b/Mesh_Onion_Skins.py
@@ -1172,7 +1172,6 @@ def format_os_material(mat, color):
     mat.diffuse_color = color  # (0.1, 0.1, 1, 0.3)
     mat.roughness = 1
     mat.blend_method = 'BLEND'
-    mat.shadow_method = 'NONE'
     mat.show_transparent_back = False
     mat.use_nodes = True
     nodes = get_material_BSDFs(mat)  # "Principled BSDF"
@@ -1227,7 +1226,6 @@ def dublicate_own_material(obj_name):
             bpy.data.materials.new(MAT_PREFIX + obj_name + '_' + SUFFIX_own)
             mat = bpy.data.materials[MAT_PREFIX + obj_name + '_' + SUFFIX_own]
         mat.blend_method = 'BLEND'
-        mat.shadow_method = 'NONE'
         mat.show_transparent_back = False
         mat.use_nodes = True
     return mat

--- a/Mesh_Onion_Skins.py
+++ b/Mesh_Onion_Skins.py
@@ -671,7 +671,8 @@ class OS_PT_UI_Panel(Panel):
     bl_region_type = "UI"
     bl_category = "Animation"
 
-    def __init__(self):
+    def __init__(self, /, *args, **kwargs):
+        super().__init__(*args, **kwargs)
         OS_Initialization()
 
     @classmethod
@@ -1972,7 +1973,8 @@ class GPU_OT_Draw_Skins(Operator):
     bl_description = "Draw onion skins in 3D Viewport"
     bl_options = {'REGISTER'}
 
-    def __init__(self):
+    def __init__(self, /, *args, **kwargs):
+        super().__init__(*args, **kwargs)
         self.sc = bpy.context.scene.onion_skins_scene_props
         self.frames_count = None
         self.before = None
@@ -2430,7 +2432,8 @@ class OS_OT_CreateUpdate_Skins(Operator):
     processing = False
     job_done = False
 
-    def __init__(self):
+    def __init__(self, /, *args, **kwargs):
+        super().__init__(*args, **kwargs)
         self.sc = bpy.context.scene.onion_skins_scene_props
         self.params = bpy.context.window_manager.onionSkinsParams
         self.obj = bpy.context.active_object

--- a/README.md
+++ b/README.md
@@ -1,7 +1,5 @@
 Supported Blender version: **2.83+**
 
-[**Download**](https://github.com/tingjoybits/Mesh_Onion_Skins/releases/latest/download/Mesh_Onion_Skins115.zip) <- file
-
 **INSTALLATION**
 - Open Blender and select **Edit->Preferences**
 


### PR DESCRIPTION
The problem was a recent change in the blender material API (see first commit) and how operators/Panel constructors were initialized in this addon (see second commit).

1. Since the new eevee material settings in 4.2+, shadow method was removed from the python API. To achieve the same result, a custom node setup is required, see : https://blender.stackexchange.com/questions/339206/how-do-i-disable-shadow-visibility-in-the-eevee-material-settings-in-blender-ver
2. Blender can now dereference an ill-initialized builtin type, provoking an `blender ReferenceError: StructRNA of type X has been removed` error. This is fixed by forcing the base class to be initialized FIRST with ALL their parameters.

This fixes issue #10 